### PR TITLE
Refactor NumberToWordsNepali class to use static method

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ dependencies:
 ```dart
 import 'package:number_to_words_nepali/number_to_words_nepali.dart';
 
-print('123456789: ${NumberToWordsNepali().convertNumberToWordsNepali(123456789)}');
+print('123456789: ${NumberToWordsNepali.convertNumberToWordsNepali(123456789)}');
 // 123456789: बाह्र करोड चौतीस लाख छपन्न हजार सात सय उनान्नब्बे
 
-print('123456789: ${NumberToWordsNepali(language: Language.english).convertNumberToWordsNepali(123456789)}');
+print('123456789: ${NumberToWordsNepali.convertNumberToWordsNepali(123456789,language: Language.english)}');
 // 123456789: twelve crore thirty-four lakh fifty-six thousand seven hundred eighty-nine
 ```
 

--- a/example/example.dart
+++ b/example/example.dart
@@ -2,42 +2,42 @@ import 'package:number_to_words_nepali/number_to_words_nepali.dart';
 
 void main() {
   //* Nepali language
-  print('10000: ${NumberToWordsNepali().convertNumberToWordsNepali(10000)}');
+  print('10000: ${NumberToWordsNepali.convertNumberToWordsNepali(10000)}');
   // 10000: दस हजार
 
-  print('100001: ${NumberToWordsNepali().convertNumberToWordsNepali(100001)}');
+  print('100001: ${NumberToWordsNepali.convertNumberToWordsNepali(100001)}');
   // 100001: एक लाख एक
 
   print(
-      '11111111: ${NumberToWordsNepali().convertNumberToWordsNepali(11111111)}');
+      '11111111: ${NumberToWordsNepali.convertNumberToWordsNepali(11111111)}');
   // 11111111: एक करोड एघार लाख एघार हजार एक सय एघार
 
   print(
-      '123456789: ${NumberToWordsNepali().convertNumberToWordsNepali(123456789)}');
+      '123456789: ${NumberToWordsNepali.convertNumberToWordsNepali(123456789)}');
   // 123456789: बाह्र करोड चौतीस लाख छपन्न हजार सात सय उनान्नब्बे
 
   print(
-      '999999999999999999: ${NumberToWordsNepali().convertNumberToWordsNepali(999999999999999999)}');
+      '999999999999999999: ${NumberToWordsNepali.convertNumberToWordsNepali(999999999999999999)}');
   // 999999999999999999: नौ शंख उनान्सय पद्म उनान्सय नील उनान्सय खरब उनान्सय अरब उनान्सय करोड उनान्सय लाख उनान्सय हजार नौ सय उनान्सय
 
   //* English language
   print(
-      '10000: ${NumberToWordsNepali(language: Language.english).convertNumberToWordsNepali(10000)}');
+      '10000: ${NumberToWordsNepali.convertNumberToWordsNepali(10000, language: Language.english)}');
   // 10000: ten thousand
 
   print(
-      '100001: ${NumberToWordsNepali(language: Language.english).convertNumberToWordsNepali(100001)}');
+      '100001: ${NumberToWordsNepali.convertNumberToWordsNepali(100001, language: Language.english)}');
   // 100001: one lakh one
 
   print(
-      '11111111: ${NumberToWordsNepali(language: Language.english).convertNumberToWordsNepali(11111111)}');
+      '11111111: ${NumberToWordsNepali.convertNumberToWordsNepali(11111111, language: Language.english)}');
   // 11111111: one crore eleven lakh eleven thousand one hundred eleven
 
   print(
-      '123456789: ${NumberToWordsNepali(language: Language.english).convertNumberToWordsNepali(123456789)}');
+      '123456789: ${NumberToWordsNepali.convertNumberToWordsNepali(123456789, language: Language.english)}');
   // 123456789: twelve crore thirty-four lakh fifty-six thousand seven hundred eighty-nine
 
   print(
-      '999999999999999999: ${NumberToWordsNepali(language: Language.english).convertNumberToWordsNepali(999999999999999999)}');
+      '999999999999999999: ${NumberToWordsNepali.convertNumberToWordsNepali(999999999999999999, language: Language.english)}');
   // 999999999999999999:  nine shankh ninety-nine padma ninety-nine neel ninety-nine kharab ninety-nine arab ninety-nine crore ninety-nine lakh ninety-nine thousand nine hundred ninety-nine
 }

--- a/lib/src/number_to_words_nepali.dart
+++ b/lib/src/number_to_words_nepali.dart
@@ -1,24 +1,17 @@
-import 'package:number_to_words_nepali/number_to_words_nepali.dart';
 import 'package:number_to_words_nepali/src/constants.dart';
+import 'package:number_to_words_nepali/src/language.dart';
 
 /// A class to convert numbers to their Nepali word representations.
 class NumberToWordsNepali {
-  /// Specifies the language for number to words conversion
-  final Language language;
-
-  /// Creates an instance of the [NumberToWordsNepali] class.
+  /// Static method to a number to its word representation in Nepali.
+  ///
+  /// Takes an [int] number as input and returns its corresponding words in Nepali.
   ///
   /// The [language] parameter specifies the language for the number-to-words conversion.
   ///
   /// If [language] is not provided, the default language is set to [Language.nepali].
-  NumberToWordsNepali({
-    this.language = Language.nepali,
-  });
-
-  /// Converts a number to its word representation in Nepali.
-  ///
-  /// Takes an [int] number as input and returns its corresponding words in Nepali.
-  String convertNumberToWordsNepali(int number) {
+  static String convertNumberToWordsNepali(int number,
+      {Language language = Language.nepali}) {
     String numberInWords = '';
     String commaFormattedNumber = _formatWithComma(number);
     List<String> digitGroups = commaFormattedNumber.split(',');
@@ -33,7 +26,7 @@ class NumberToWordsNepali {
       if (digits[0] == '0') digits = digits.substring(1);
 
       digits =
-          '${_wordForUnitNumber(int.parse(digits))} ${counts[digitGroups.length - i]} ';
+          '${_wordForUnitNumber(int.parse(digits), language)} ${counts[digitGroups.length - i]} ';
 
       numberInWords += digits;
     }
@@ -43,21 +36,21 @@ class NumberToWordsNepali {
     if (hundredDigits.length == 3) {
       if (hundredDigits[0] != '0') {
         numberInWords +=
-            '${_wordForUnitNumber(int.parse(hundredDigits[0]))} ${counts[1]} ';
+            '${_wordForUnitNumber(int.parse(hundredDigits[0]), language)} ${counts[1]} ';
       }
       hundredDigits = hundredDigits.substring(1);
     }
 
     if (hundredDigits != '00') {
       if (hundredDigits[0] == '0') hundredDigits = hundredDigits.substring(1);
-      numberInWords += _wordForUnitNumber(int.parse(hundredDigits));
+      numberInWords += _wordForUnitNumber(int.parse(hundredDigits), language);
     }
 
     return numberInWords.trim();
   }
 
   /// Formats the number with commas (e.g., 1,00,00,000) for easier conversion.
-  String _formatWithComma(int number) {
+  static String _formatWithComma(int number) {
     String numberString = number.toString();
     String formattedNumber = '';
     int count = 0;
@@ -77,7 +70,7 @@ class NumberToWordsNepali {
   }
 
   /// Returns the word representation for a unit number in the specified language.
-  String _wordForUnitNumber(int number) {
+  static String _wordForUnitNumber(int number, Language language) {
     String numberInWords = '';
 
     if (language == Language.nepali) {

--- a/test/number_to_words_nepali_test.dart
+++ b/test/number_to_words_nepali_test.dart
@@ -14,7 +14,7 @@ void main() {
 
     for (var testNumber in testNumbers.entries) {
       test('${testNumber.key}: ${testNumber.value}', () {
-        expect(NumberToWordsNepali().convertNumberToWordsNepali(testNumber.key),
+        expect(NumberToWordsNepali.convertNumberToWordsNepali(testNumber.key),
             testNumber.value);
       });
     }
@@ -34,8 +34,8 @@ void main() {
     for (var testNumber in testNumbers.entries) {
       test('${testNumber.key}: ${testNumber.value}', () {
         expect(
-            NumberToWordsNepali(language: Language.english)
-                .convertNumberToWordsNepali(testNumber.key),
+            NumberToWordsNepali.convertNumberToWordsNepali(testNumber.key,
+                language: Language.english),
             testNumber.value);
       });
     }


### PR DESCRIPTION
- This PR refactors the NumberToWordsNepali class to use a static method instead of a class constructor. This change eliminates the need for creating an instance of the class to use the convertNumberToWordsNepali method.

- The convertNumberToWordsNepali method has been moved to a static method in the NumberToWordsNepali class. The constructor has been removed, and the language parameter has been moved to the convertNumberToWordsNepali method.

Please review and let me know if there are any issues with these changes.
